### PR TITLE
fix: Add `exports` key to `package.json`.

### DIFF
--- a/.changeset/quiet-pumas-warn.md
+++ b/.changeset/quiet-pumas-warn.md
@@ -1,0 +1,5 @@
+---
+'yeezy-dates': patch
+---
+
+fix: Add `exports` key to `package.json`.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "dev": "vitest",
     "test": "vitest run",


### PR DESCRIPTION
I was trying to use this package but I was getting errors because `exports` didn't exist. Added this to a patch and it worked so pushing it upstream.